### PR TITLE
feat(observability): implement Grafana, Loki, and Jaeger with security fixes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,10 +13,10 @@ Tag your assigned review partner based on your role area
 | Role | Reviewers |
 |------|-----------|
 | **Backend** | @mahorobonheur @GargoilXD |
-| **Frontend** | @Bentil4 |
-| **DevOps/Infra** | @Viateur-akimana |
-| **QA** | @Lennox-Owusu |
-| **Data Engineering** | @Damas200 |
+| **Frontend** |  @nabbi007 |
+| **DevOps/Infra** | @nabbi007 |
+| **QA** | @Samuel1796 |
+| **Data Engineering** | @henryantwi |
 
 > PRs to `main` **require** @Lennox-Owusu approval
 

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -101,6 +101,7 @@ jobs:
           TF_VAR_frontend_image: ${{ env.ECR_REGISTRY }}/${{ vars.PROJECT_NAME }}-frontend:${{ env.IMAGE_TAG }}
           TF_VAR_db_password: ${{ secrets.DB_PASSWORD }}
           TF_VAR_jwt_secret: ${{ secrets.JWT_SECRET }}
+          TF_VAR_slack_webhook_url: ${{ secrets.SLACK_DEPLOYMENTS_WEBHOOK }}
 
       - name: Terraform Apply
         working-directory: ./infrastructure/environments/prod

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -104,6 +104,7 @@ jobs:
           TF_VAR_frontend_image: ${{ env.ECR_REGISTRY }}/${{ vars.PROJECT_NAME }}-frontend:${{ env.IMAGE_TAG }}
           TF_VAR_db_password: ${{ secrets.DB_PASSWORD }}
           TF_VAR_jwt_secret: ${{ secrets.JWT_SECRET }}
+          TF_VAR_slack_webhook_url: ${{ secrets.SLACK_DEPLOYMENTS_WEBHOOK }}
 
       - name: Terraform Apply
         working-directory: ./infrastructure/environments/staging

--- a/.github/workflows/terraform-pipeline.yml
+++ b/.github/workflows/terraform-pipeline.yml
@@ -89,6 +89,7 @@ jobs:
           TF_VAR_frontend_image: "placeholder:latest"
           TF_VAR_db_password: ${{ secrets.DB_PASSWORD }}
           TF_VAR_jwt_secret: ${{ secrets.JWT_SECRET }}
+          TF_VAR_slack_webhook_url: ${{ secrets.SLACK_DEPLOYMENTS_WEBHOOK }}
         continue-on-error: true
 
       - name: Post plan to PR comment
@@ -175,6 +176,7 @@ jobs:
           TF_VAR_frontend_image: "placeholder:latest"
           TF_VAR_db_password: ${{ secrets.DB_PASSWORD }}
           TF_VAR_jwt_secret: ${{ secrets.JWT_SECRET }}
+          TF_VAR_slack_webhook_url: ${{ secrets.SLACK_DEPLOYMENTS_WEBHOOK }}
 
       - name: Terraform Apply
         if: inputs.action == 'apply'
@@ -190,3 +192,4 @@ jobs:
           TF_VAR_frontend_image: "placeholder:latest"
           TF_VAR_db_password: ${{ secrets.DB_PASSWORD }}
           TF_VAR_jwt_secret: ${{ secrets.JWT_SECRET }}
+          TF_VAR_slack_webhook_url: ${{ secrets.SLACK_DEPLOYMENTS_WEBHOOK }}

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -113,6 +113,18 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-tracing-bridge-otel</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-otlp</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -48,6 +48,16 @@ management:
     metrics:
       export:
         enabled: true
+  tracing:
+    sampling:
+      probability: 1.0
+  otlp:
+    tracing:
+      endpoint: http://jaeger:4318/v1/traces
+
+logging:
+  pattern:
+    level: "%5p [traceId=%X{traceId:-},spanId=%X{spanId:-}]"
 
 jwt:
   secret: ${JWT_SECRET}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,7 +70,13 @@ services:
       postgres:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:${SERVER_PORT:-8081}/actuator/health"]
+      test:
+        [
+          "CMD",
+          "curl",
+          "-sf",
+          "http://localhost:${SERVER_PORT:-8081}/actuator/health",
+        ]
       interval: 30s
       timeout: 10s
       retries: 5
@@ -168,7 +174,14 @@ services:
     restart: unless-stopped
     ports:
       - "6379:6379"
-    command: ["redis-server", "--maxmemory", "128mb", "--maxmemory-policy", "allkeys-lru"]
+    command:
+      [
+        "redis-server",
+        "--maxmemory",
+        "128mb",
+        "--maxmemory-policy",
+        "allkeys-lru",
+      ]
     volumes:
       - redis-data:/data
     healthcheck:
@@ -292,6 +305,76 @@ services:
     networks:
       - quickpoll-network
 
+  # Loki
+  loki:
+    image: grafana/loki:3.0.0
+    container_name: quickpoll-loki
+    restart: unless-stopped
+    profiles: ["monitoring"]
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./monitoring/loki/loki-config.yml:/etc/loki/loki-config.yml:ro
+      - loki-data:/loki
+    command: -config.file=/etc/loki/loki-config.yml
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:3100/ready || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 256M
+    networks:
+      - quickpoll-network
+
+  # Promtail
+  promtail:
+    image: grafana/promtail:3.0.0
+    container_name: quickpoll-promtail
+    restart: unless-stopped
+    profiles: ["monitoring"]
+    volumes:
+      - ./monitoring/promtail/promtail-config.yml:/etc/promtail/config.yml:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+    command: -config.file=/etc/promtail/config.yml
+    depends_on:
+      - loki
+    deploy:
+      resources:
+        limits:
+          cpus: "0.25"
+          memory: 128M
+    networks:
+      - quickpoll-network
+
+  # Jaeger
+  jaeger:
+    image: jaegertracing/all-in-one:1.55
+    container_name: quickpoll-jaeger
+    restart: unless-stopped
+    profiles: ["monitoring"]
+    ports:
+      - "16686:16686"
+      - "4317:4317"
+      - "4318:4318"
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:16686/ || exit 1"]
+      interval: 10s
+      timeout: 5s
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 512M
+    networks:
+      - quickpoll-network
+
 volumes:
   pgdata:
     driver: local
@@ -302,6 +385,8 @@ volumes:
   prometheus-data:
     driver: local
   grafana-data:
+    driver: local
+  loki-data:
     driver: local
 
 networks:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,471 @@
+# QuickPoll — Setup & Deployment Guide
+
+## Table of Contents
+
+- [Architecture Overview](#architecture-overview)
+- [Prerequisites](#prerequisites)
+- [Local Development](#local-development)
+- [Infrastructure Overview](#infrastructure-overview)
+- [AWS Deployment](#aws-deployment)
+  - [Initial Setup](#initial-setup)
+  - [Staging Deployment](#staging-deployment)
+  - [Production Deployment](#production-deployment)
+- [CI/CD Pipelines](#cicd-pipelines)
+- [Redis Configuration](#redis-configuration)
+- [Environment Variables Reference](#environment-variables-reference)
+- [Monitoring](#monitoring)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## Architecture Overview
+
+QuickPoll is a full-stack real-time polling platform:
+
+| Component        | Technology              | Port |
+|------------------|-------------------------|------|
+| Backend API      | Spring Boot 3.2 / Java 21 | 8081 |
+| Frontend         | Angular 19 / Nginx      | 8080 |
+| Database         | PostgreSQL 16           | 5432 |
+| Cache            | Redis 7                 | 6379 |
+| Data Engineering | Python 3.11 ETL         | —    |
+
+**AWS Architecture (per environment):**
+
+```
+Internet → ALB (80/443)
+             ├── /api/*  → ECS Backend (port 8081, Fargate)
+             └── /*      → ECS Frontend (port 8080, Fargate)
+
+ECS Backend → RDS PostgreSQL (private subnets, port 5432)
+ECS Backend → ElastiCache Redis (private subnets, port 6379)
+```
+
+- **VPC**: 2 AZs, public + private subnets, NAT Gateways
+- **ECS Fargate**: Autoscaling on CPU/memory targets
+- **RDS**: Multi-AZ (prod), automated backups, CloudWatch alarms
+- **ElastiCache Redis**: Single-node (staging `cache.t3.micro`), larger in prod (`cache.t3.small`)
+- **ECR**: Separate repos for backend, frontend, data-engineering
+
+---
+
+## Prerequisites
+
+### Tools Required
+
+| Tool        | Version   | Purpose                   |
+|-------------|-----------|---------------------------|
+| Docker      | 24+       | Containerization          |
+| Docker Compose | v2     | Local development         |
+| Terraform   | ≥ 1.7.0   | Infrastructure as Code    |
+| AWS CLI     | v2        | AWS resource management   |
+| Node.js     | 20.x      | Frontend build            |
+| Java        | 21 (Temurin) | Backend build          |
+| Maven       | 3.9.x     | Backend dependency mgmt   |
+
+### AWS Account Setup
+
+1. **AWS Account** with programmatic access
+2. **S3 Bucket** for Terraform state: `quickpoll-team7-tf-state`
+3. **DynamoDB Table** for state locking: `quickpoll-team7-tf-lock`
+4. **IAM User/Role** with permissions for: ECS, ECR, RDS, ElastiCache, VPC, ALB, S3, DynamoDB, SSM, CloudWatch, SNS, IAM
+
+---
+
+## Local Development
+
+### 1. Clone & Configure
+
+```bash
+git clone git@github.com:QuickPoll-app/QuickPoll.git
+cd QuickPoll
+```
+
+Create a `.env` file in the project root:
+
+```env
+POSTGRES_DB=quickpoll
+POSTGRES_USER=quickpoll
+POSTGRES_PASSWORD=your_local_password
+JWT_SECRET=your_local_jwt_secret_at_least_32_chars
+```
+
+### 2. Start Services
+
+```bash
+# Start app services (backend, frontend, postgres, redis)
+docker compose up -d --build
+
+# Start with monitoring stack (Prometheus, Grafana, Alertmanager)
+docker compose --profile monitoring up -d --build
+```
+
+### 3. Access Points
+
+| Service     | URL                                |
+|-------------|------------------------------------|
+| Frontend    | http://localhost:8080               |
+| Backend API | http://localhost:8081               |
+| Swagger UI  | http://localhost:8081/swagger-ui.html |
+| Grafana     | http://localhost:3000 (admin/admin) |
+| Prometheus  | http://localhost:9090               |
+
+### 4. Default Users
+
+| Email                 | Password    | Role  |
+|-----------------------|-------------|-------|
+| admin@quickpoll.com   | password123 | Admin |
+| user@quickpoll.com    | password123 | User  |
+
+### 5. Common Commands
+
+```bash
+docker compose logs -f backend         # Follow backend logs
+docker compose logs -f frontend        # Follow frontend logs
+docker compose ps                      # Show service status
+docker compose down -v                 # Stop and remove volumes
+docker compose restart backend         # Restart backend only
+```
+
+---
+
+## Infrastructure Overview
+
+### Terraform Module Structure
+
+```
+infrastructure/
+├── environments/
+│   ├── staging/          # Staging env config
+│   │   ├── main.tf       # Module composition
+│   │   ├── variables.tf  # Env-specific variables
+│   │   ├── outputs.tf    # Env outputs
+│   │   └── terraform.tfvars.example
+│   └── prod/             # Production env config
+│       ├── main.tf
+│       ├── variables.tf
+│       ├── outputs.tf
+│       └── terraform.tfvars.example
+└── modules/
+    ├── networking/       # VPC, subnets, NAT, IGW
+    ├── security/         # Security groups (ALB, ECS, RDS, Redis), IAM roles
+    ├── database/         # RDS PostgreSQL, backup alarms, SNS events
+    ├── redis/            # ElastiCache Redis cluster
+    ├── loadbalancer/     # ALB, target groups, listener rules
+    ├── compute/          # ECR repositories
+    ├── ecs/              # ECS cluster, task definitions, services, autoscaling
+    └── storage/          # S3 buckets
+```
+
+### Security Groups
+
+| Security Group | Inbound From      | Port(s)    |
+|----------------|-------------------|------------|
+| ALB SG         | 0.0.0.0/0         | 80, 443    |
+| ECS Tasks SG   | ALB SG            | 8080, 8081 |
+| RDS SG         | ECS Tasks SG      | 5432       |
+| Redis SG       | ECS Tasks SG      | 6379       |
+
+### Redis ↔ ECS Flow
+
+Redis is fully internal — no GitHub Secrets needed:
+
+```
+Terraform creates ElastiCache → outputs redis_host & redis_port
+    ↓
+Passed as module outputs to ECS module via environments/main.tf
+    ↓
+ECS task definition injects SPRING_DATA_REDIS_HOST & SPRING_DATA_REDIS_PORT
+    ↓
+Spring Boot auto-configures Redis connection from env vars
+```
+
+---
+
+## AWS Deployment
+
+### Initial Setup
+
+#### 1. Create Terraform State Backend
+
+```bash
+# Create S3 bucket for state
+aws s3api create-bucket \
+  --bucket quickpoll-team7-tf-state \
+  --region eu-north-1 \
+  --create-bucket-configuration LocationConstraint=eu-north-1
+
+# Enable versioning
+aws s3api put-bucket-versioning \
+  --bucket quickpoll-team7-tf-state \
+  --versioning-configuration Status=Enabled
+
+# Create DynamoDB lock table
+aws dynamodb create-table \
+  --table-name quickpoll-team7-tf-lock \
+  --attribute-definitions AttributeName=LockID,AttributeType=S \
+  --key-schema AttributeName=LockID,KeyType=HASH \
+  --billing-mode PAY_PER_REQUEST \
+  --region eu-north-1
+```
+
+#### 2. Configure GitHub Secrets & Variables
+
+**Repository Secrets** (Settings → Secrets and variables → Actions):
+
+| Secret Name              | Description                        |
+|--------------------------|------------------------------------|
+| `AWS_ACCESS_KEY_ID`      | IAM access key                     |
+| `AWS_SECRET_ACCESS_KEY`  | IAM secret key                     |
+| `TF_VAR_DB_PASSWORD`     | RDS master password                |
+| `TF_VAR_JWT_SECRET`      | JWT signing secret (≥32 chars)     |
+| `CI_DB_PASSWORD`         | CI test database password          |
+| `CI_JWT_SECRET`          | CI test JWT secret                 |
+| `SLACK_DEPLOYMENTS_WEBHOOK` | Slack webhook for notifications |
+
+**Repository Variables**:
+
+| Variable Name  | Value                |
+|----------------|----------------------|
+| `PROJECT_NAME` | `quickpoll-team7`    |
+| `AWS_REGION`   | `eu-north-1`         |
+| `CI_DB_NAME`   | `quickpoll_test`     |
+| `CI_DB_USER`   | `quickpoll_test`     |
+
+#### 3. Configure GitHub Environments
+
+Create two GitHub Environments: **staging** and **prod**.
+
+- **staging**: Auto-deploys on merge to `develop`
+- **prod**: Requires manual approval, deploys on merge to `main`
+
+### Staging Deployment
+
+#### Manual (first time / debugging)
+
+```bash
+cd infrastructure/environments/staging
+
+# Initialize with S3 backend
+terraform init \
+  -backend-config="bucket=quickpoll-team7-tf-state" \
+  -backend-config="key=staging/terraform.tfstate" \
+  -backend-config="region=eu-north-1" \
+  -backend-config="dynamodb_table=quickpoll-team7-tf-lock"
+
+# Plan
+export TF_VAR_db_password="your_staging_db_password"
+export TF_VAR_jwt_secret="your_staging_jwt_secret"
+export TF_VAR_backend_image="442426888142.dkr.ecr.eu-north-1.amazonaws.com/quickpoll-team7-staging-backend:latest"
+export TF_VAR_frontend_image="442426888142.dkr.ecr.eu-north-1.amazonaws.com/quickpoll-team7-staging-frontend:latest"
+
+terraform plan -out=tfplan
+
+# Apply
+terraform apply tfplan
+```
+
+#### Automated (CI/CD)
+
+Push to `develop` branch → `deploy-staging.yml` runs automatically:
+1. Builds & pushes Docker images to ECR
+2. Runs `terraform apply` with GitHub Secrets
+3. Updates ECS services with new images
+
+### Production Deployment
+
+#### Automated (CI/CD)
+
+Merge PR to `main` branch → `deploy-prod.yml` runs with manual approval:
+1. Same flow as staging but with prod-sized resources
+2. Multi-AZ RDS, higher ECS autoscaling limits
+3. Larger Redis node (`cache.t3.small`)
+
+---
+
+## CI/CD Pipelines
+
+| Workflow                | Trigger                          | Purpose                                    |
+|-------------------------|----------------------------------|--------------------------------------------|
+| `ci.yml`                | Push to develop/feature/hotfix, PR to main/develop | Lint, test, build, docker build, Terraform validate |
+| `deploy-staging.yml`    | Merge to `develop`               | Build images → push to ECR → terraform apply staging |
+| `deploy-prod.yml`       | Merge to `main`                  | Build images → push to ECR → terraform apply prod    |
+| `deploy-hotfix.yml`     | Merge hotfix/* to `main`         | Fast-track prod deployment                 |
+| `terraform-pipeline.yml`| Manual / infrastructure changes  | Terraform plan/apply with approval         |
+
+### CI Checks (required to pass)
+
+- `backend-test` — Maven verify with PostgreSQL service container
+- `frontend-build` — npm lint + production build
+- `terraform-validate` — `terraform fmt -check` + `terraform validate` (staging & prod)
+- `docker-build` — Build all 3 Docker images (no push)
+
+---
+
+## Redis Configuration
+
+### How It Works
+
+The backend Spring Boot application uses Redis for **caching** (`spring.cache.type=redis`). Redis connection details are injected as environment variables:
+
+| Env Variable              | Source                              | Spring Property             |
+|---------------------------|-------------------------------------|-----------------------------|
+| `SPRING_DATA_REDIS_HOST`  | Terraform → ElastiCache endpoint    | `spring.data.redis.host`    |
+| `SPRING_DATA_REDIS_PORT`  | Terraform → ElastiCache port (6379) | `spring.data.redis.port`    |
+
+### Local Development
+
+In `docker-compose.yml`, a local Redis container runs alongside the app:
+- Host: `redis` (Docker network DNS)
+- Port: `6379`
+
+### AWS Environments
+
+ElastiCache Redis is provisioned per environment:
+
+| Environment | Node Type        | Snapshots       | Maintenance Window    |
+|-------------|------------------|-----------------|-----------------------|
+| Staging     | `cache.t3.micro` | 1-day retention | Sun 05:00–06:00 UTC   |
+| Production  | `cache.t3.small` | 7-day retention | Sun 05:00–06:00 UTC   |
+
+No secrets needed — the Redis endpoint is auto-generated by Terraform and passed between modules:
+
+```hcl
+# In environments/staging/main.tf (or prod)
+module "ecs" {
+  ...
+  redis_host = module.redis.redis_host   # Auto from ElastiCache
+  redis_port = module.redis.redis_port   # Auto from ElastiCache
+}
+```
+
+---
+
+## Environment Variables Reference
+
+### Backend (ECS Task Definition)
+
+| Variable                      | Source    | Description                    |
+|-------------------------------|----------|--------------------------------|
+| `SPRING_DATASOURCE_URL`       | Terraform | JDBC URL to RDS               |
+| `SPRING_DATASOURCE_USERNAME`  | Terraform | DB username                   |
+| `SPRING_DATASOURCE_PASSWORD`  | SSM      | DB password (SecureString)     |
+| `JWT_SECRET`                  | SSM      | JWT signing key (SecureString) |
+| `SPRING_JPA_HIBERNATE_DDL_AUTO` | Terraform | Hibernate DDL mode (update) |
+| `SPRING_PROFILES_ACTIVE`      | Terraform | Active Spring profile         |
+| `SERVER_PORT`                 | Terraform | Server port (8081)            |
+| `SPRING_DATA_REDIS_HOST`      | Terraform | Redis endpoint from ElastiCache |
+| `SPRING_DATA_REDIS_PORT`      | Terraform | Redis port (6379)             |
+
+### Local Development (.env)
+
+| Variable           | Description              |
+|--------------------|--------------------------|
+| `POSTGRES_DB`      | PostgreSQL database name |
+| `POSTGRES_USER`    | PostgreSQL username      |
+| `POSTGRES_PASSWORD`| PostgreSQL password      |
+| `JWT_SECRET`       | JWT signing key          |
+
+---
+
+## Monitoring
+
+Start with monitoring profile:
+
+```bash
+docker compose --profile monitoring up -d
+```
+
+| Service      | URL                    | Credentials    |
+|--------------|------------------------|----------------|
+| Grafana      | http://localhost:3000   | admin / admin  |
+| Prometheus   | http://localhost:9090   | —              |
+| Alertmanager | http://localhost:9093   | —              |
+
+### Key Metrics
+
+- **Backend**: Spring Boot actuator at `/actuator/prometheus`
+- **RDS** (AWS): CloudWatch alarms for CPU > 80%, free storage < 5GB, connection count
+- **ECS**: Autoscaling on CPU and memory utilization targets
+
+---
+
+## Troubleshooting
+
+### Common Issues
+
+**ECS tasks failing to start**
+```bash
+# Check task logs
+aws ecs describe-tasks \
+  --cluster quickpoll-team7-staging \
+  --tasks <task-id> \
+  --query 'tasks[0].stoppedReason'
+
+# Check CloudWatch logs
+aws logs tail /ecs/quickpoll-team7-staging-backend --follow
+```
+
+**RDS connection refused**
+- Verify ECS tasks SG has egress to RDS SG on port 5432
+- Check SSM parameter `/<project>/<env>/db-password` matches RDS password
+- Run: `aws ssm get-parameter --name "/quickpoll-team7/staging/db-password" --with-decryption`
+
+**Redis connection refused**
+- Verify Redis SG allows inbound from ECS tasks SG on port 6379
+- Check ElastiCache cluster status: `aws elasticache describe-cache-clusters`
+- Verify ECS task definition has `SPRING_DATA_REDIS_HOST` env var set
+
+**Terraform state lock**
+```bash
+terraform force-unlock <LOCK_ID>
+```
+
+**Terraform fmt check failing in CI**
+```bash
+# Auto-format all files
+terraform fmt -recursive infrastructure/
+git add -A && git commit -m "style(infra): terraform fmt" && git push
+```
+
+**Docker build cache issues**
+```bash
+docker compose build --no-cache
+```
+
+### Useful AWS CLI Commands
+
+```bash
+# List ECS services
+aws ecs list-services --cluster quickpoll-team7-staging
+
+# Force new deployment (pull latest image)
+aws ecs update-service \
+  --cluster quickpoll-team7-staging \
+  --service quickpoll-team7-staging-backend \
+  --force-new-deployment
+
+# Check ElastiCache Redis endpoint
+aws elasticache describe-cache-clusters \
+  --cache-cluster-id quickpoll-team7-staging-redis \
+  --show-cache-node-info \
+  --query 'CacheClusters[0].CacheNodes[0].Endpoint'
+
+# Check RDS status
+aws rds describe-db-instances \
+  --db-instance-identifier quickpoll-team7-staging-db \
+  --query 'DBInstances[0].DBInstanceStatus'
+```
+
+---
+
+## Git Branching Strategy
+
+| Branch          | Purpose                  | Deploys To |
+|-----------------|--------------------------|------------|
+| `main`          | Production-ready code    | Production |
+| `develop`       | Integration branch       | Staging    |
+| `feature/*`     | New features             | CI only    |
+| `hotfix/*`      | Urgent production fixes  | Production |
+
+See [docs/git-branching-strategy.md](docs/git-branching-strategy.md) for full details.

--- a/infrastructure/environments/prod/main.tf
+++ b/infrastructure/environments/prod/main.tf
@@ -163,9 +163,11 @@ module "monitoring" {
   monitoring_target_group_arn    = module.loadbalancer.monitoring_target_group_arn
   jaeger_target_group_arn        = module.loadbalancer.jaeger_target_group_arn
   efs_monitoring_id              = module.storage.efs_monitoring_id
-  efs_access_point_grafana_id    = module.storage.efs_access_point_grafana_id
-  efs_access_point_loki_id       = module.storage.efs_access_point_loki_id
-  grafana_admin_password         = "admin123" # In production use a secret
+  efs_access_point_grafana_id     = module.storage.efs_access_point_grafana_id
+  efs_access_point_loki_id        = module.storage.efs_access_point_loki_id
+  efs_access_point_prometheus_id  = module.storage.efs_access_point_prometheus_id
+  efs_access_point_alertmanager_id = module.storage.efs_access_point_alertmanager_id
+  grafana_admin_password          = "admin123" # In production use a secret
   slack_webhook_url              = var.slack_webhook_url
   tags                           = local.tags
 }

--- a/infrastructure/environments/prod/main.tf
+++ b/infrastructure/environments/prod/main.tf
@@ -148,11 +148,32 @@ module "ecs" {
   tags        = local.tags
 }
 
+# Monitoring (Grafana, Loki, Jaeger)
+module "monitoring" {
+  source = "../../modules/monitoring"
+
+  project_name                 = var.project_name
+  environment                  = local.environment
+  vpc_id                       = module.networking.vpc_id
+  private_subnet_ids           = module.networking.private_subnet_ids
+  monitoring_security_group_id = module.security.monitoring_security_group_id
+  ecs_task_execution_role_arn  = module.security.ecs_task_execution_role_arn
+  monitoring_target_group_arn  = module.loadbalancer.monitoring_target_group_arn
+  jaeger_target_group_arn      = module.loadbalancer.jaeger_target_group_arn
+  efs_monitoring_id            = module.storage.efs_monitoring_id
+  efs_access_point_grafana_id  = module.storage.efs_access_point_grafana_id
+  efs_access_point_loki_id     = module.storage.efs_access_point_loki_id
+  grafana_admin_password       = "admin123" # In production use a secret
+  tags                         = local.tags
+}
+
 # Storage
 module "storage" {
   source = "../../modules/storage"
 
-  project_name = var.project_name
-  environment  = local.environment
-  tags         = local.tags
+  project_name          = var.project_name
+  environment           = local.environment
+  private_subnet_ids    = module.networking.private_subnet_ids
+  efs_security_group_id = module.security.efs_security_group_id
+  tags                  = local.tags
 }

--- a/infrastructure/environments/prod/main.tf
+++ b/infrastructure/environments/prod/main.tf
@@ -153,23 +153,23 @@ module "ecs" {
 module "monitoring" {
   source = "../../modules/monitoring"
 
-  project_name                   = var.project_name
-  environment                    = local.environment
-  vpc_id                         = module.networking.vpc_id
-  private_subnet_ids             = module.networking.private_subnet_ids
-  service_discovery_namespace_id = module.networking.service_discovery_namespace_id
-  monitoring_security_group_id   = module.security.monitoring_security_group_id
-  ecs_task_execution_role_arn    = module.security.ecs_task_execution_role_arn
-  monitoring_target_group_arn    = module.loadbalancer.monitoring_target_group_arn
-  jaeger_target_group_arn        = module.loadbalancer.jaeger_target_group_arn
-  efs_monitoring_id              = module.storage.efs_monitoring_id
-  efs_access_point_grafana_id     = module.storage.efs_access_point_grafana_id
-  efs_access_point_loki_id        = module.storage.efs_access_point_loki_id
-  efs_access_point_prometheus_id  = module.storage.efs_access_point_prometheus_id
+  project_name                     = var.project_name
+  environment                      = local.environment
+  vpc_id                           = module.networking.vpc_id
+  private_subnet_ids               = module.networking.private_subnet_ids
+  service_discovery_namespace_id   = module.networking.service_discovery_namespace_id
+  monitoring_security_group_id     = module.security.monitoring_security_group_id
+  ecs_task_execution_role_arn      = module.security.ecs_task_execution_role_arn
+  monitoring_target_group_arn      = module.loadbalancer.monitoring_target_group_arn
+  jaeger_target_group_arn          = module.loadbalancer.jaeger_target_group_arn
+  efs_monitoring_id                = module.storage.efs_monitoring_id
+  efs_access_point_grafana_id      = module.storage.efs_access_point_grafana_id
+  efs_access_point_loki_id         = module.storage.efs_access_point_loki_id
+  efs_access_point_prometheus_id   = module.storage.efs_access_point_prometheus_id
   efs_access_point_alertmanager_id = module.storage.efs_access_point_alertmanager_id
-  grafana_admin_password          = "admin123" # In production use a secret
-  slack_webhook_url              = var.slack_webhook_url
-  tags                           = local.tags
+  grafana_admin_password           = "admin123" # In production use a secret
+  slack_webhook_url                = var.slack_webhook_url
+  tags                             = local.tags
 }
 
 # Storage

--- a/infrastructure/environments/prod/main.tf
+++ b/infrastructure/environments/prod/main.tf
@@ -111,23 +111,24 @@ module "compute" {
 module "ecs" {
   source = "../../modules/ecs"
 
-  project_name                = var.project_name
-  environment                 = local.environment
-  aws_region                  = var.aws_region
-  private_subnet_ids          = module.networking.private_subnet_ids
-  ecs_tasks_security_group_id = module.security.ecs_tasks_security_group_id
-  ecs_task_execution_role_arn = module.security.ecs_task_execution_role_arn
-  ecs_task_role_arn           = module.security.ecs_task_role_arn
-  backend_target_group_arn    = module.loadbalancer.backend_target_group_arn
-  frontend_target_group_arn   = module.loadbalancer.frontend_target_group_arn
-  backend_image               = var.backend_image
-  frontend_image              = var.frontend_image
-  backend_cpu                 = var.backend_cpu
-  backend_memory              = var.backend_memory
-  frontend_cpu                = var.frontend_cpu
-  frontend_memory             = var.frontend_memory
-  backend_desired_count       = var.backend_desired_count
-  frontend_desired_count      = var.frontend_desired_count
+  project_name                   = var.project_name
+  environment                    = local.environment
+  aws_region                     = var.aws_region
+  private_subnet_ids             = module.networking.private_subnet_ids
+  ecs_tasks_security_group_id    = module.security.ecs_tasks_security_group_id
+  ecs_task_execution_role_arn    = module.security.ecs_task_execution_role_arn
+  ecs_task_role_arn              = module.security.ecs_task_role_arn
+  backend_target_group_arn       = module.loadbalancer.backend_target_group_arn
+  frontend_target_group_arn      = module.loadbalancer.frontend_target_group_arn
+  backend_image                  = var.backend_image
+  frontend_image                 = var.frontend_image
+  backend_cpu                    = var.backend_cpu
+  backend_memory                 = var.backend_memory
+  frontend_cpu                   = var.frontend_cpu
+  frontend_memory                = var.frontend_memory
+  backend_desired_count          = var.backend_desired_count
+  frontend_desired_count         = var.frontend_desired_count
+  service_discovery_namespace_id = module.networking.service_discovery_namespace_id
 
   # Autoscaling — prod runs higher capacity
   backend_min_count      = 2
@@ -148,23 +149,25 @@ module "ecs" {
   tags        = local.tags
 }
 
-# Monitoring (Grafana, Loki, Jaeger)
+# Monitoring (Grafana, Loki, Jaeger, Prometheus, Alertmanager)
 module "monitoring" {
   source = "../../modules/monitoring"
 
-  project_name                 = var.project_name
-  environment                  = local.environment
-  vpc_id                       = module.networking.vpc_id
-  private_subnet_ids           = module.networking.private_subnet_ids
-  monitoring_security_group_id = module.security.monitoring_security_group_id
-  ecs_task_execution_role_arn  = module.security.ecs_task_execution_role_arn
-  monitoring_target_group_arn  = module.loadbalancer.monitoring_target_group_arn
-  jaeger_target_group_arn      = module.loadbalancer.jaeger_target_group_arn
-  efs_monitoring_id            = module.storage.efs_monitoring_id
-  efs_access_point_grafana_id  = module.storage.efs_access_point_grafana_id
-  efs_access_point_loki_id     = module.storage.efs_access_point_loki_id
-  grafana_admin_password       = "admin123" # In production use a secret
-  tags                         = local.tags
+  project_name                   = var.project_name
+  environment                    = local.environment
+  vpc_id                         = module.networking.vpc_id
+  private_subnet_ids             = module.networking.private_subnet_ids
+  service_discovery_namespace_id = module.networking.service_discovery_namespace_id
+  monitoring_security_group_id   = module.security.monitoring_security_group_id
+  ecs_task_execution_role_arn    = module.security.ecs_task_execution_role_arn
+  monitoring_target_group_arn    = module.loadbalancer.monitoring_target_group_arn
+  jaeger_target_group_arn        = module.loadbalancer.jaeger_target_group_arn
+  efs_monitoring_id              = module.storage.efs_monitoring_id
+  efs_access_point_grafana_id    = module.storage.efs_access_point_grafana_id
+  efs_access_point_loki_id       = module.storage.efs_access_point_loki_id
+  grafana_admin_password         = "admin123" # In production use a secret
+  slack_webhook_url              = var.slack_webhook_url
+  tags                           = local.tags
 }
 
 # Storage

--- a/infrastructure/environments/prod/variables.tf
+++ b/infrastructure/environments/prod/variables.tf
@@ -44,6 +44,12 @@ variable "jwt_secret" {
   sensitive   = true
 }
 
+variable "slack_webhook_url" {
+  description = "Slack webhook URL for Grafana alerts - passed via TF_VAR_slack_webhook_url from GitHub Secrets"
+  type        = string
+  sensitive   = true
+}
+
 # Sizing (prod runs larger)
 variable "db_instance_class" {
   description = "RDS instance class"

--- a/infrastructure/environments/staging/main.tf
+++ b/infrastructure/environments/staging/main.tf
@@ -109,23 +109,24 @@ module "compute" {
 module "ecs" {
   source = "../../modules/ecs"
 
-  project_name                = var.project_name
-  environment                 = local.environment
-  aws_region                  = var.aws_region
-  private_subnet_ids          = module.networking.private_subnet_ids
-  ecs_tasks_security_group_id = module.security.ecs_tasks_security_group_id
-  ecs_task_execution_role_arn = module.security.ecs_task_execution_role_arn
-  ecs_task_role_arn           = module.security.ecs_task_role_arn
-  backend_target_group_arn    = module.loadbalancer.backend_target_group_arn
-  frontend_target_group_arn   = module.loadbalancer.frontend_target_group_arn
-  backend_image               = var.backend_image
-  frontend_image              = var.frontend_image
-  backend_cpu                 = var.backend_cpu
-  backend_memory              = var.backend_memory
-  frontend_cpu                = var.frontend_cpu
-  frontend_memory             = var.frontend_memory
-  backend_desired_count       = var.backend_desired_count
-  frontend_desired_count      = var.frontend_desired_count
+  project_name                   = var.project_name
+  environment                    = local.environment
+  aws_region                     = var.aws_region
+  private_subnet_ids             = module.networking.private_subnet_ids
+  ecs_tasks_security_group_id    = module.security.ecs_tasks_security_group_id
+  ecs_task_execution_role_arn    = module.security.ecs_task_execution_role_arn
+  ecs_task_role_arn              = module.security.ecs_task_role_arn
+  backend_target_group_arn       = module.loadbalancer.backend_target_group_arn
+  frontend_target_group_arn      = module.loadbalancer.frontend_target_group_arn
+  backend_image                  = var.backend_image
+  frontend_image                 = var.frontend_image
+  backend_cpu                    = var.backend_cpu
+  backend_memory                 = var.backend_memory
+  frontend_cpu                   = var.frontend_cpu
+  frontend_memory                = var.frontend_memory
+  backend_desired_count          = var.backend_desired_count
+  frontend_desired_count         = var.frontend_desired_count
+  service_discovery_namespace_id = module.networking.service_discovery_namespace_id
 
   # Autoscaling — staging runs conservative
   backend_min_count      = 1
@@ -150,19 +151,21 @@ module "ecs" {
 module "monitoring" {
   source = "../../modules/monitoring"
 
-  project_name                 = var.project_name
-  environment                  = local.environment
-  vpc_id                       = module.networking.vpc_id
-  private_subnet_ids           = module.networking.private_subnet_ids
-  monitoring_security_group_id = module.security.monitoring_security_group_id
-  ecs_task_execution_role_arn  = module.security.ecs_task_execution_role_arn
-  monitoring_target_group_arn  = module.loadbalancer.monitoring_target_group_arn
-  jaeger_target_group_arn      = module.loadbalancer.jaeger_target_group_arn
-  efs_monitoring_id            = module.storage.efs_monitoring_id
-  efs_access_point_grafana_id  = module.storage.efs_access_point_grafana_id
-  efs_access_point_loki_id     = module.storage.efs_access_point_loki_id
-  grafana_admin_password       = "admin123" # In production use a secret
-  tags                         = local.tags
+  project_name                   = var.project_name
+  environment                    = local.environment
+  vpc_id                         = module.networking.vpc_id
+  private_subnet_ids             = module.networking.private_subnet_ids
+  service_discovery_namespace_id = module.networking.service_discovery_namespace_id
+  monitoring_security_group_id   = module.security.monitoring_security_group_id
+  ecs_task_execution_role_arn    = module.security.ecs_task_execution_role_arn
+  monitoring_target_group_arn    = module.loadbalancer.monitoring_target_group_arn
+  jaeger_target_group_arn        = module.loadbalancer.jaeger_target_group_arn
+  efs_monitoring_id              = module.storage.efs_monitoring_id
+  efs_access_point_grafana_id    = module.storage.efs_access_point_grafana_id
+  efs_access_point_loki_id       = module.storage.efs_access_point_loki_id
+  grafana_admin_password         = "admin123" # In production use a secret
+  slack_webhook_url              = var.slack_webhook_url
+  tags                           = local.tags
 }
 
 # Storage

--- a/infrastructure/environments/staging/main.tf
+++ b/infrastructure/environments/staging/main.tf
@@ -161,9 +161,11 @@ module "monitoring" {
   monitoring_target_group_arn    = module.loadbalancer.monitoring_target_group_arn
   jaeger_target_group_arn        = module.loadbalancer.jaeger_target_group_arn
   efs_monitoring_id              = module.storage.efs_monitoring_id
-  efs_access_point_grafana_id    = module.storage.efs_access_point_grafana_id
-  efs_access_point_loki_id       = module.storage.efs_access_point_loki_id
-  grafana_admin_password         = "admin123" # In production use a secret
+  efs_access_point_grafana_id     = module.storage.efs_access_point_grafana_id
+  efs_access_point_loki_id        = module.storage.efs_access_point_loki_id
+  efs_access_point_prometheus_id  = module.storage.efs_access_point_prometheus_id
+  efs_access_point_alertmanager_id = module.storage.efs_access_point_alertmanager_id
+  grafana_admin_password          = "admin123" # In production use a secret
   slack_webhook_url              = var.slack_webhook_url
   tags                           = local.tags
 }

--- a/infrastructure/environments/staging/main.tf
+++ b/infrastructure/environments/staging/main.tf
@@ -146,11 +146,32 @@ module "ecs" {
   tags        = local.tags
 }
 
+# Monitoring (Grafana, Loki, Jaeger)
+module "monitoring" {
+  source = "../../modules/monitoring"
+
+  project_name                 = var.project_name
+  environment                  = local.environment
+  vpc_id                       = module.networking.vpc_id
+  private_subnet_ids           = module.networking.private_subnet_ids
+  monitoring_security_group_id = module.security.monitoring_security_group_id
+  ecs_task_execution_role_arn  = module.security.ecs_task_execution_role_arn
+  monitoring_target_group_arn  = module.loadbalancer.monitoring_target_group_arn
+  jaeger_target_group_arn      = module.loadbalancer.jaeger_target_group_arn
+  efs_monitoring_id            = module.storage.efs_monitoring_id
+  efs_access_point_grafana_id  = module.storage.efs_access_point_grafana_id
+  efs_access_point_loki_id     = module.storage.efs_access_point_loki_id
+  grafana_admin_password       = "admin123" # In production use a secret
+  tags                         = local.tags
+}
+
 # Storage
 module "storage" {
   source = "../../modules/storage"
 
-  project_name = var.project_name
-  environment  = local.environment
-  tags         = local.tags
+  project_name          = var.project_name
+  environment           = local.environment
+  private_subnet_ids    = module.networking.private_subnet_ids
+  efs_security_group_id = module.security.efs_security_group_id
+  tags                  = local.tags
 }

--- a/infrastructure/environments/staging/main.tf
+++ b/infrastructure/environments/staging/main.tf
@@ -151,23 +151,23 @@ module "ecs" {
 module "monitoring" {
   source = "../../modules/monitoring"
 
-  project_name                   = var.project_name
-  environment                    = local.environment
-  vpc_id                         = module.networking.vpc_id
-  private_subnet_ids             = module.networking.private_subnet_ids
-  service_discovery_namespace_id = module.networking.service_discovery_namespace_id
-  monitoring_security_group_id   = module.security.monitoring_security_group_id
-  ecs_task_execution_role_arn    = module.security.ecs_task_execution_role_arn
-  monitoring_target_group_arn    = module.loadbalancer.monitoring_target_group_arn
-  jaeger_target_group_arn        = module.loadbalancer.jaeger_target_group_arn
-  efs_monitoring_id              = module.storage.efs_monitoring_id
-  efs_access_point_grafana_id     = module.storage.efs_access_point_grafana_id
-  efs_access_point_loki_id        = module.storage.efs_access_point_loki_id
-  efs_access_point_prometheus_id  = module.storage.efs_access_point_prometheus_id
+  project_name                     = var.project_name
+  environment                      = local.environment
+  vpc_id                           = module.networking.vpc_id
+  private_subnet_ids               = module.networking.private_subnet_ids
+  service_discovery_namespace_id   = module.networking.service_discovery_namespace_id
+  monitoring_security_group_id     = module.security.monitoring_security_group_id
+  ecs_task_execution_role_arn      = module.security.ecs_task_execution_role_arn
+  monitoring_target_group_arn      = module.loadbalancer.monitoring_target_group_arn
+  jaeger_target_group_arn          = module.loadbalancer.jaeger_target_group_arn
+  efs_monitoring_id                = module.storage.efs_monitoring_id
+  efs_access_point_grafana_id      = module.storage.efs_access_point_grafana_id
+  efs_access_point_loki_id         = module.storage.efs_access_point_loki_id
+  efs_access_point_prometheus_id   = module.storage.efs_access_point_prometheus_id
   efs_access_point_alertmanager_id = module.storage.efs_access_point_alertmanager_id
-  grafana_admin_password          = "admin123" # In production use a secret
-  slack_webhook_url              = var.slack_webhook_url
-  tags                           = local.tags
+  grafana_admin_password           = "admin123" # In production use a secret
+  slack_webhook_url                = var.slack_webhook_url
+  tags                             = local.tags
 }
 
 # Storage

--- a/infrastructure/environments/staging/variables.tf
+++ b/infrastructure/environments/staging/variables.tf
@@ -44,6 +44,12 @@ variable "jwt_secret" {
   sensitive   = true
 }
 
+variable "slack_webhook_url" {
+  description = "Slack webhook URL for Grafana alerts - passed via TF_VAR_slack_webhook_url from GitHub Secrets"
+  type        = string
+  sensitive   = true
+}
+
 # Sizing
 variable "db_instance_class" {
   description = "RDS instance class"

--- a/infrastructure/modules/ecs/main.tf
+++ b/infrastructure/modules/ecs/main.tf
@@ -106,6 +106,7 @@ resource "aws_ecs_task_definition" "backend" {
         { name = "SERVER_PORT", value = "8081" },
         { name = "SPRING_DATA_REDIS_HOST", value = var.redis_host },
         { name = "SPRING_DATA_REDIS_PORT", value = var.redis_port },
+        { name = "MANAGEMENT_OTLP_TRACING_ENDPOINT", value = "http://jaeger.monitoring.local:4318/v1/traces" }
       ]
 
       secrets = [
@@ -114,11 +115,14 @@ resource "aws_ecs_task_definition" "backend" {
       ]
 
       logConfiguration = {
-        logDriver = "awslogs"
+        logDriver = "awsfirelens"
         options = {
-          "awslogs-group"         = aws_cloudwatch_log_group.backend.name
-          "awslogs-region"        = var.aws_region
-          "awslogs-stream-prefix" = "backend"
+          "Name"       = "loki"
+          "Url"        = "http://loki.monitoring.local:3100/loki/api/v1/push"
+          "Labels"     = "{job=\"backend\", env=\"${var.environment}\"}"
+          "RemoveKeys" = "container_id,container_name"
+          "LabelKeys"  = "container_name"
+          "LineFormat" = "key_value"
         }
       }
 
@@ -128,6 +132,26 @@ resource "aws_ecs_task_definition" "backend" {
         timeout     = 10
         retries     = 3
         startPeriod = 60
+      }
+    },
+    {
+      name      = "log_router"
+      image     = "amazon/aws-for-fluent-bit:latest"
+      essential = true
+      firelensConfiguration = {
+        type = "fluentbit"
+        options = {
+          "enable-ecs-log-metadata" = "true"
+        }
+      }
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = "/ecs/${var.project_name}-${var.environment}-firelens"
+          "awslogs-region"        = var.aws_region
+          "awslogs-stream-prefix" = "firelens"
+          "awslogs-create-group"  = "true"
+        }
       }
     }
   ])

--- a/infrastructure/modules/ecs/main.tf
+++ b/infrastructure/modules/ecs/main.tf
@@ -208,6 +208,22 @@ resource "aws_ecs_task_definition" "frontend" {
   })
 }
 
+# Service Discovery for Backend
+resource "aws_service_discovery_service" "backend" {
+  name = "backend"
+
+  dns_config {
+    namespace_id = var.service_discovery_namespace_id
+    dns_records {
+      ttl  = 60
+      type = "A"
+    }
+  }
+
+  health_check_custom_config {
+  }
+}
+
 # Backend Service
 resource "aws_ecs_service" "backend" {
   name            = trimsuffix(substr("${var.project_name}-${var.environment}-backend", 0, 255), "-")
@@ -226,6 +242,10 @@ resource "aws_ecs_service" "backend" {
     target_group_arn = var.backend_target_group_arn
     container_name   = "backend"
     container_port   = 8081
+  }
+
+  service_registries {
+    registry_arn = aws_service_discovery_service.backend.arn
   }
 
   deployment_circuit_breaker {

--- a/infrastructure/modules/ecs/variables.tf
+++ b/infrastructure/modules/ecs/variables.tf
@@ -39,6 +39,11 @@ variable "ecs_task_role_arn" {
   type        = string
 }
 
+variable "service_discovery_namespace_id" {
+  description = "ID of the Cloud Map private DNS namespace"
+  type        = string
+}
+
 variable "backend_target_group_arn" {
   description = "ARN of the backend ALB target group"
   type        = string

--- a/infrastructure/modules/loadbalancer/main.tf
+++ b/infrastructure/modules/loadbalancer/main.tf
@@ -66,6 +66,54 @@ resource "aws_lb_target_group" "frontend" {
   })
 }
 
+# Grafana Target Group
+resource "aws_lb_target_group" "monitoring" {
+  name        = trimsuffix(substr("${var.project_name}-${var.environment}-mon-tg", 0, 32), "-")
+  port        = 3000
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+  target_type = "ip"
+
+  health_check {
+    enabled             = true
+    path                = "/api/health"
+    port                = "traffic-port"
+    healthy_threshold   = 3
+    unhealthy_threshold = 3
+    timeout             = 5
+    interval            = 30
+    matcher             = "200"
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.project_name}-${var.environment}-mon-tg"
+  })
+}
+
+# Jaeger Target Group
+resource "aws_lb_target_group" "jaeger" {
+  name        = trimsuffix(substr("${var.project_name}-${var.environment}-jae-tg", 0, 32), "-")
+  port        = 16686
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+  target_type = "ip"
+
+  health_check {
+    enabled             = true
+    path                = "/"
+    port                = "traffic-port"
+    healthy_threshold   = 3
+    unhealthy_threshold = 3
+    timeout             = 5
+    interval            = 30
+    matcher             = "200"
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.project_name}-${var.environment}-jae-tg"
+  })
+}
+
 # HTTP Listener (default → frontend)
 resource "aws_lb_listener" "http" {
   load_balancer_arn = aws_lb.main.arn
@@ -100,5 +148,47 @@ resource "aws_lb_listener_rule" "api" {
 
   tags = merge(var.tags, {
     Name = "${var.project_name}-${var.environment}-api-rule"
+  })
+}
+
+# Grafana Path Rule → Monitoring
+resource "aws_lb_listener_rule" "monitoring" {
+  listener_arn = aws_lb_listener.http.arn
+  priority     = 110
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.monitoring.arn
+  }
+
+  condition {
+    path_pattern {
+      values = ["/grafana/*"]
+    }
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.project_name}-${var.environment}-mon-rule"
+  })
+}
+
+# Jaeger Path Rule → Jaeger UI
+resource "aws_lb_listener_rule" "jaeger" {
+  listener_arn = aws_lb_listener.http.arn
+  priority     = 120
+
+  action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.jaeger.arn
+  }
+
+  condition {
+    path_pattern {
+      values = ["/jaeger/*"]
+    }
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.project_name}-${var.environment}-jaeger-rule"
   })
 }

--- a/infrastructure/modules/loadbalancer/outputs.tf
+++ b/infrastructure/modules/loadbalancer/outputs.tf
@@ -1,7 +1,6 @@
 
 # Load Balancer Module - Outputs
 
-
 output "alb_arn" {
   description = "ARN of the Application Load Balancer"
   value       = aws_lb.main.arn
@@ -25,6 +24,16 @@ output "backend_target_group_arn" {
 output "frontend_target_group_arn" {
   description = "ARN of the frontend target group"
   value       = aws_lb_target_group.frontend.arn
+}
+
+output "monitoring_target_group_arn" {
+  description = "ARN of the monitoring (Grafana) target group"
+  value       = aws_lb_target_group.monitoring.arn
+}
+
+output "jaeger_target_group_arn" {
+  description = "ARN of the Jaeger target group"
+  value       = aws_lb_target_group.jaeger.arn
 }
 
 output "http_listener_arn" {

--- a/infrastructure/modules/monitoring/main.tf
+++ b/infrastructure/modules/monitoring/main.tf
@@ -264,6 +264,16 @@ resource "aws_ecs_task_definition" "prometheus" {
       portMappings = [
         { containerPort = 9090, protocol = "tcp" }
       ]
+      mountPoints = [
+        {
+          containerPath = "/etc/prometheus"
+          sourceVolume  = "prometheus-config"
+        },
+        {
+          containerPath = "/prometheus"
+          sourceVolume  = "prometheus-data"
+        }
+      ]
       environment = [
         { name = "BACKEND_HOST", value = "backend.${var.project_name}-${var.environment}.local" }
       ]
@@ -278,6 +288,35 @@ resource "aws_ecs_task_definition" "prometheus" {
       }
     }
   ])
+
+  volume {
+    name = "prometheus-config"
+    efs_volume_configuration {
+      file_system_id     = var.efs_monitoring_id
+      transit_encryption = "ENABLED"
+      authorization_config {
+        access_point_id = var.efs_access_point_prometheus_id
+        iam             = "DISABLED"
+      }
+    }
+  }
+
+  volume {
+    name = "prometheus-data"
+    # We use the same EFS but a different access point for data? 
+    # Actually, the user asked for config. Let's keep data in the container or separate AP if needed.
+    # For now, let's just do config as requested.
+    efs_volume_configuration {
+      file_system_id     = var.efs_monitoring_id
+      transit_encryption = "ENABLED"
+      authorization_config {
+        # Using a subpath /data within the prometheus AP or a new one. 
+        # Let's just mount the same AP and let it manage subdirs.
+        access_point_id = var.efs_access_point_prometheus_id
+        iam             = "DISABLED"
+      }
+    }
+  }
 }
 
 resource "aws_ecs_service" "prometheus" {
@@ -328,6 +367,12 @@ resource "aws_ecs_task_definition" "alertmanager" {
       portMappings = [
         { containerPort = 9093, protocol = "tcp" }
       ]
+      mountPoints = [
+        {
+          containerPath = "/etc/alertmanager"
+          sourceVolume  = "alertmanager-config"
+        }
+      ]
       environment = [
         { name = "SLACK_WEBHOOK_URL", value = var.slack_webhook_url }
       ]
@@ -342,6 +387,18 @@ resource "aws_ecs_task_definition" "alertmanager" {
       }
     }
   ])
+
+  volume {
+    name = "alertmanager-config"
+    efs_volume_configuration {
+      file_system_id     = var.efs_monitoring_id
+      transit_encryption = "ENABLED"
+      authorization_config {
+        access_point_id = var.efs_access_point_alertmanager_id
+        iam             = "DISABLED"
+      }
+    }
+  }
 }
 
 resource "aws_ecs_service" "alertmanager" {

--- a/infrastructure/modules/monitoring/main.tf
+++ b/infrastructure/modules/monitoring/main.tf
@@ -1,12 +1,5 @@
-
 # Monitoring Module - Main Configuration
 # Grafana, Loki, Jaeger on ECS Fargate
-
-resource "aws_service_discovery_private_dns_namespace" "monitoring" {
-  name        = "monitoring.local"
-  description = "Private DNS for monitoring services"
-  vpc         = var.vpc_id
-}
 
 # Jaeger
 
@@ -14,7 +7,7 @@ resource "aws_service_discovery_service" "jaeger" {
   name = "jaeger"
 
   dns_config {
-    namespace_id = aws_service_discovery_private_dns_namespace.monitoring.id
+    namespace_id = var.service_discovery_namespace_id
     dns_records {
       ttl  = 60
       type = "A"
@@ -88,7 +81,7 @@ resource "aws_service_discovery_service" "loki" {
   name = "loki"
 
   dns_config {
-    namespace_id = aws_service_discovery_private_dns_namespace.monitoring.id
+    namespace_id = var.service_discovery_namespace_id
     dns_records {
       ttl  = 60
       type = "A"
@@ -183,7 +176,8 @@ resource "aws_ecs_task_definition" "grafana" {
       environment = [
         { name = "GF_SECURITY_ADMIN_PASSWORD", value = var.grafana_admin_password },
         { name = "GF_SERVER_ROOT_URL", value = "/grafana/" },
-        { name = "GF_SERVER_SERVE_FROM_SUB_PATH", value = "true" }
+        { name = "GF_SERVER_SERVE_FROM_SUB_PATH", value = "true" },
+        { name = "SLACK_WEBHOOK_URL", value = var.slack_webhook_url }
       ]
       mountPoints = [
         {
@@ -232,5 +226,137 @@ resource "aws_ecs_service" "grafana" {
     target_group_arn = var.monitoring_target_group_arn
     container_name   = "grafana"
     container_port   = 3000
+  }
+}
+
+# Prometheus
+resource "aws_service_discovery_service" "prometheus" {
+  name = "prometheus"
+
+  dns_config {
+    namespace_id = var.service_discovery_namespace_id
+    dns_records {
+      ttl  = 60
+      type = "A"
+    }
+  }
+
+  health_check_custom_config {
+  }
+}
+
+resource "aws_ecs_task_definition" "prometheus" {
+  family                   = "${var.project_name}-${var.environment}-prometheus"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = 512
+  memory                   = 1024
+  execution_role_arn       = var.ecs_task_execution_role_arn
+
+  container_definitions = jsonencode([
+    {
+      name  = "prometheus"
+      image = "prom/prometheus:v2.50.1"
+      command = [
+        "--config.file=/etc/prometheus/prometheus.yml",
+        "--storage.tsdb.path=/prometheus"
+      ]
+      portMappings = [
+        { containerPort = 9090, protocol = "tcp" }
+      ]
+      environment = [
+        { name = "BACKEND_HOST", value = "backend.${var.project_name}-${var.environment}.local" }
+      ]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = "/ecs/${var.project_name}-${var.environment}-prometheus"
+          "awslogs-region"        = "eu-north-1"
+          "awslogs-stream-prefix" = "prometheus"
+          "awslogs-create-group"  = "true"
+        }
+      }
+    }
+  ])
+}
+
+resource "aws_ecs_service" "prometheus" {
+  name            = "${var.project_name}-${var.environment}-prometheus"
+  cluster         = "${var.project_name}-${var.environment}-cluster"
+  task_definition = aws_ecs_task_definition.prometheus.arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets         = var.private_subnet_ids
+    security_groups = [var.monitoring_security_group_id]
+  }
+
+  service_registries {
+    registry_arn = aws_service_discovery_service.prometheus.arn
+  }
+}
+
+# Alertmanager
+resource "aws_service_discovery_service" "alertmanager" {
+  name = "alertmanager"
+
+  dns_config {
+    namespace_id = var.service_discovery_namespace_id
+    dns_records {
+      ttl  = 60
+      type = "A"
+    }
+  }
+
+  health_check_custom_config {
+  }
+}
+
+resource "aws_ecs_task_definition" "alertmanager" {
+  family                   = "${var.project_name}-${var.environment}-alertmanager"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = 256
+  memory                   = 512
+  execution_role_arn       = var.ecs_task_execution_role_arn
+
+  container_definitions = jsonencode([
+    {
+      name  = "alertmanager"
+      image = "prom/alertmanager:v0.27.0"
+      portMappings = [
+        { containerPort = 9093, protocol = "tcp" }
+      ]
+      environment = [
+        { name = "SLACK_WEBHOOK_URL", value = var.slack_webhook_url }
+      ]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = "/ecs/${var.project_name}-${var.environment}-alertmanager"
+          "awslogs-region"        = "eu-north-1"
+          "awslogs-stream-prefix" = "alertmanager"
+          "awslogs-create-group"  = "true"
+        }
+      }
+    }
+  ])
+}
+
+resource "aws_ecs_service" "alertmanager" {
+  name            = "${var.project_name}-${var.environment}-alertmanager"
+  cluster         = "${var.project_name}-${var.environment}-cluster"
+  task_definition = aws_ecs_task_definition.alertmanager.arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets         = var.private_subnet_ids
+    security_groups = [var.monitoring_security_group_id]
+  }
+
+  service_registries {
+    registry_arn = aws_service_discovery_service.alertmanager.arn
   }
 }

--- a/infrastructure/modules/monitoring/main.tf
+++ b/infrastructure/modules/monitoring/main.tf
@@ -1,0 +1,236 @@
+
+# Monitoring Module - Main Configuration
+# Grafana, Loki, Jaeger on ECS Fargate
+
+resource "aws_service_discovery_private_dns_namespace" "monitoring" {
+  name        = "monitoring.local"
+  description = "Private DNS for monitoring services"
+  vpc         = var.vpc_id
+}
+
+# Jaeger
+
+resource "aws_service_discovery_service" "jaeger" {
+  name = "jaeger"
+
+  dns_config {
+    namespace_id = aws_service_discovery_private_dns_namespace.monitoring.id
+    dns_records {
+      ttl  = 60
+      type = "A"
+    }
+  }
+
+  health_check_custom_config {
+  }
+}
+
+resource "aws_ecs_task_definition" "jaeger" {
+  family                   = "${var.project_name}-${var.environment}-jaeger"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = 512
+  memory                   = 1024
+  execution_role_arn       = var.ecs_task_execution_role_arn
+
+  container_definitions = jsonencode([
+    {
+      name  = "jaeger"
+      image = "jaegertracing/all-in-one:1.55"
+      portMappings = [
+        { containerPort = 16686, protocol = "tcp" },
+        { containerPort = 4317, protocol = "tcp" },
+        { containerPort = 4318, protocol = "tcp" }
+      ]
+      environment = [
+        { name = "COLLECTOR_OTLP_ENABLED", value = "true" },
+        { name = "QUERY_BASE_PATH", value = "/jaeger" }
+      ]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = "/ecs/${var.project_name}-${var.environment}-jaeger"
+          "awslogs-region"        = "eu-north-1"
+          "awslogs-stream-prefix" = "jaeger"
+          "awslogs-create-group"  = "true"
+        }
+      }
+    }
+  ])
+}
+
+resource "aws_ecs_service" "jaeger" {
+  name            = "${var.project_name}-${var.environment}-jaeger"
+  cluster         = "${var.project_name}-${var.environment}-cluster"
+  task_definition = aws_ecs_task_definition.jaeger.arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets         = var.private_subnet_ids
+    security_groups = [var.monitoring_security_group_id]
+  }
+
+  load_balancer {
+    target_group_arn = var.jaeger_target_group_arn
+    container_name   = "jaeger"
+    container_port   = 16686
+  }
+
+  service_registries {
+    registry_arn = aws_service_discovery_service.jaeger.arn
+  }
+}
+
+# Loki
+
+resource "aws_service_discovery_service" "loki" {
+  name = "loki"
+
+  dns_config {
+    namespace_id = aws_service_discovery_private_dns_namespace.monitoring.id
+    dns_records {
+      ttl  = 60
+      type = "A"
+    }
+  }
+
+  health_check_custom_config {
+  }
+}
+
+resource "aws_ecs_task_definition" "loki" {
+  family                   = "${var.project_name}-${var.environment}-loki"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = 512
+  memory                   = 1024
+  execution_role_arn       = var.ecs_task_execution_role_arn
+
+  container_definitions = jsonencode([
+    {
+      name    = "loki"
+      image   = "grafana/loki:3.0.0"
+      command = ["-config.file=/etc/loki/local-config.yaml"]
+      portMappings = [
+        { containerPort = 3100, protocol = "tcp" }
+      ]
+      mountPoints = [
+        {
+          containerPath = "/loki"
+          sourceVolume  = "loki-data"
+        }
+      ]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = "/ecs/${var.project_name}-${var.environment}-loki"
+          "awslogs-region"        = "eu-north-1"
+          "awslogs-stream-prefix" = "loki"
+          "awslogs-create-group"  = "true"
+        }
+      }
+    }
+  ])
+
+  volume {
+    name = "loki-data"
+    efs_volume_configuration {
+      file_system_id     = var.efs_monitoring_id
+      transit_encryption = "ENABLED"
+      authorization_config {
+        access_point_id = var.efs_access_point_loki_id
+        iam             = "DISABLED"
+      }
+    }
+  }
+}
+
+resource "aws_ecs_service" "loki" {
+  name            = "${var.project_name}-${var.environment}-loki"
+  cluster         = "${var.project_name}-${var.environment}-cluster"
+  task_definition = aws_ecs_task_definition.loki.arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets         = var.private_subnet_ids
+    security_groups = [var.monitoring_security_group_id]
+  }
+
+  service_registries {
+    registry_arn = aws_service_discovery_service.loki.arn
+  }
+}
+
+# Grafana
+
+resource "aws_ecs_task_definition" "grafana" {
+  family                   = "${var.project_name}-${var.environment}-grafana"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = 512
+  memory                   = 1024
+  execution_role_arn       = var.ecs_task_execution_role_arn
+
+  container_definitions = jsonencode([
+    {
+      name  = "grafana"
+      image = "grafana/grafana:10.3.3"
+      portMappings = [
+        { containerPort = 3000, protocol = "tcp" }
+      ]
+      environment = [
+        { name = "GF_SECURITY_ADMIN_PASSWORD", value = var.grafana_admin_password },
+        { name = "GF_SERVER_ROOT_URL", value = "/grafana/" },
+        { name = "GF_SERVER_SERVE_FROM_SUB_PATH", value = "true" }
+      ]
+      mountPoints = [
+        {
+          containerPath = "/var/lib/grafana"
+          sourceVolume  = "grafana-data"
+        }
+      ]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = "/ecs/${var.project_name}-${var.environment}-grafana"
+          "awslogs-region"        = "eu-north-1"
+          "awslogs-stream-prefix" = "grafana"
+          "awslogs-create-group"  = "true"
+        }
+      }
+    }
+  ])
+
+  volume {
+    name = "grafana-data"
+    efs_volume_configuration {
+      file_system_id     = var.efs_monitoring_id
+      transit_encryption = "ENABLED"
+      authorization_config {
+        access_point_id = var.efs_access_point_grafana_id
+        iam             = "DISABLED"
+      }
+    }
+  }
+}
+
+resource "aws_ecs_service" "grafana" {
+  name            = "${var.project_name}-${var.environment}-grafana"
+  cluster         = "${var.project_name}-${var.environment}-cluster"
+  task_definition = aws_ecs_task_definition.grafana.arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets         = var.private_subnet_ids
+    security_groups = [var.monitoring_security_group_id]
+  }
+
+  load_balancer {
+    target_group_arn = var.monitoring_target_group_arn
+    container_name   = "grafana"
+    container_port   = 3000
+  }
+}

--- a/infrastructure/modules/monitoring/outputs.tf
+++ b/infrastructure/modules/monitoring/outputs.tf
@@ -1,0 +1,5 @@
+
+output "service_discovery_namespace_id" {
+  description = "ID of the Cloud Map private DNS namespace"
+  value       = aws_service_discovery_private_dns_namespace.monitoring.id
+}

--- a/infrastructure/modules/monitoring/outputs.tf
+++ b/infrastructure/modules/monitoring/outputs.tf
@@ -1,5 +1,5 @@
 
 output "service_discovery_namespace_id" {
   description = "ID of the Cloud Map private DNS namespace"
-  value       = aws_service_discovery_private_dns_namespace.monitoring.id
+  value       = var.service_discovery_namespace_id
 }

--- a/infrastructure/modules/monitoring/variables.tf
+++ b/infrastructure/modules/monitoring/variables.tf
@@ -1,0 +1,54 @@
+
+variable "project_name" {
+  type = string
+}
+
+variable "environment" {
+  type = string
+}
+
+variable "vpc_id" {
+  type = string
+}
+
+variable "private_subnet_ids" {
+  type = list(string)
+}
+
+variable "monitoring_security_group_id" {
+  type = string
+}
+
+variable "ecs_task_execution_role_arn" {
+  type = string
+}
+
+variable "monitoring_target_group_arn" {
+  type = string
+}
+
+variable "jaeger_target_group_arn" {
+  type = string
+}
+
+variable "efs_monitoring_id" {
+  type = string
+}
+
+variable "efs_access_point_grafana_id" {
+  type = string
+}
+
+variable "efs_access_point_loki_id" {
+  type = string
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}
+
+variable "grafana_admin_password" {
+  type    = string
+  default = "admin"
+}

--- a/infrastructure/modules/monitoring/variables.tf
+++ b/infrastructure/modules/monitoring/variables.tf
@@ -15,6 +15,10 @@ variable "private_subnet_ids" {
   type = list(string)
 }
 
+variable "service_discovery_namespace_id" {
+  type = string
+}
+
 variable "monitoring_security_group_id" {
   type = string
 }
@@ -51,4 +55,10 @@ variable "tags" {
 variable "grafana_admin_password" {
   type    = string
   default = "admin"
+}
+
+variable "slack_webhook_url" {
+  description = "Slack webhook URL for Grafana alerts"
+  type        = string
+  sensitive   = true
 }

--- a/infrastructure/modules/monitoring/variables.tf
+++ b/infrastructure/modules/monitoring/variables.tf
@@ -47,6 +47,14 @@ variable "efs_access_point_loki_id" {
   type = string
 }
 
+variable "efs_access_point_prometheus_id" {
+  type = string
+}
+
+variable "efs_access_point_alertmanager_id" {
+  type = string
+}
+
 variable "tags" {
   type    = map(string)
   default = {}

--- a/infrastructure/modules/networking/main.tf
+++ b/infrastructure/modules/networking/main.tf
@@ -112,3 +112,14 @@ resource "aws_route_table_association" "private" {
   subnet_id      = aws_subnet.private[count.index].id
   route_table_id = aws_route_table.private[count.index].id
 }
+
+# Service Discovery Namespace
+resource "aws_service_discovery_private_dns_namespace" "main" {
+  name        = "${var.project_name}-${var.environment}.local"
+  description = "Private DNS for ${var.environment} services"
+  vpc         = aws_vpc.main.id
+
+  tags = merge(var.tags, {
+    Name = "${var.project_name}-${var.environment}-ns"
+  })
+}

--- a/infrastructure/modules/networking/outputs.tf
+++ b/infrastructure/modules/networking/outputs.tf
@@ -31,3 +31,8 @@ output "nat_gateway_ids" {
   description = "IDs of the NAT Gateways"
   value       = aws_nat_gateway.main[*].id
 }
+
+output "service_discovery_namespace_id" {
+  description = "ID of the Cloud Map private DNS namespace"
+  value       = aws_service_discovery_private_dns_namespace.main.id
+}

--- a/infrastructure/modules/security/main.tf
+++ b/infrastructure/modules/security/main.tf
@@ -154,6 +154,33 @@ resource "aws_vpc_security_group_ingress_rule" "loki_from_ecs" {
   to_port                      = 3100
 }
 
+resource "aws_vpc_security_group_ingress_rule" "prometheus_from_grafana" {
+  security_group_id            = aws_security_group.monitoring.id
+  description                  = "Prometheus from Grafana"
+  referenced_security_group_id = aws_security_group.monitoring.id
+  from_port                    = 9090
+  ip_protocol                  = "tcp"
+  to_port                      = 9090
+}
+
+resource "aws_vpc_security_group_ingress_rule" "alertmanager_from_prometheus" {
+  security_group_id            = aws_security_group.monitoring.id
+  description                  = "Alertmanager from Prometheus"
+  referenced_security_group_id = aws_security_group.monitoring.id
+  from_port                    = 9093
+  ip_protocol                  = "tcp"
+  to_port                      = 9093
+}
+
+resource "aws_vpc_security_group_ingress_rule" "backend_from_prometheus" {
+  security_group_id            = aws_security_group.ecs_tasks.id
+  description                  = "Backend from Prometheus Scraper"
+  referenced_security_group_id = aws_security_group.monitoring.id
+  from_port                    = 8081
+  ip_protocol                  = "tcp"
+  to_port                      = 8081
+}
+
 resource "aws_vpc_security_group_ingress_rule" "jaeger_ui_from_alb" {
   security_group_id            = aws_security_group.monitoring.id
   description                  = "Jaeger UI from ALB"

--- a/infrastructure/modules/security/main.tf
+++ b/infrastructure/modules/security/main.tf
@@ -125,6 +125,85 @@ resource "aws_vpc_security_group_egress_rule" "redis_all_traffic" {
   ip_protocol       = "-1"
 }
 
+# Monitoring Security Group
+resource "aws_security_group" "monitoring" {
+  name        = trimsuffix(substr("${var.project_name}-${var.environment}-monitor-sg", 0, 255), "-")
+  description = "Security group for Monitoring (Grafana, Loki, Jaeger)"
+  vpc_id      = var.vpc_id
+
+  tags = merge(var.tags, {
+    Name = "${var.project_name}-${var.environment}-monitor-sg"
+  })
+}
+
+resource "aws_vpc_security_group_ingress_rule" "grafana_from_alb" {
+  security_group_id            = aws_security_group.monitoring.id
+  description                  = "Grafana from ALB"
+  referenced_security_group_id = aws_security_group.alb.id
+  from_port                    = 3000
+  ip_protocol                  = "tcp"
+  to_port                      = 3000
+}
+
+resource "aws_vpc_security_group_ingress_rule" "loki_from_ecs" {
+  security_group_id            = aws_security_group.monitoring.id
+  description                  = "Loki from ECS tasks"
+  referenced_security_group_id = aws_security_group.ecs_tasks.id
+  from_port                    = 3100
+  ip_protocol                  = "tcp"
+  to_port                      = 3100
+}
+
+resource "aws_vpc_security_group_ingress_rule" "jaeger_ui_from_alb" {
+  security_group_id            = aws_security_group.monitoring.id
+  description                  = "Jaeger UI from ALB"
+  referenced_security_group_id = aws_security_group.alb.id
+  from_port                    = 16686
+  ip_protocol                  = "tcp"
+  to_port                      = 16686
+}
+
+resource "aws_vpc_security_group_ingress_rule" "jaeger_otlp_from_ecs" {
+  security_group_id            = aws_security_group.monitoring.id
+  description                  = "Jaeger OTLP from ECS tasks"
+  referenced_security_group_id = aws_security_group.ecs_tasks.id
+  from_port                    = 4317
+  ip_protocol                  = "tcp"
+  to_port                      = 4318
+}
+
+resource "aws_vpc_security_group_egress_rule" "monitoring_all_traffic" {
+  security_group_id = aws_security_group.monitoring.id
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "-1"
+}
+
+# EFS Security Group
+resource "aws_security_group" "efs" {
+  name        = trimsuffix(substr("${var.project_name}-${var.environment}-efs-sg", 0, 255), "-")
+  description = "Security group for EFS mount targets"
+  vpc_id      = var.vpc_id
+
+  tags = merge(var.tags, {
+    Name = "${var.project_name}-${var.environment}-efs-sg"
+  })
+}
+
+resource "aws_vpc_security_group_ingress_rule" "efs_from_monitoring" {
+  security_group_id            = aws_security_group.efs.id
+  description                  = "NFS from Monitoring tasks"
+  referenced_security_group_id = aws_security_group.monitoring.id
+  from_port                    = 2049
+  ip_protocol                  = "tcp"
+  to_port                      = 2049
+}
+
+resource "aws_vpc_security_group_egress_rule" "efs_all_traffic" {
+  security_group_id = aws_security_group.efs.id
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "-1"
+}
+
 # ECS Task Execution Role
 resource "aws_iam_role" "ecs_task_execution" {
   name = trimsuffix(substr("${var.project_name}-${var.environment}-ecs-exec", 0, 64), "-")

--- a/infrastructure/modules/security/outputs.tf
+++ b/infrastructure/modules/security/outputs.tf
@@ -1,7 +1,6 @@
 
 # Security Module - Outputs
 
-
 output "alb_security_group_id" {
   description = "Security group ID for the ALB"
   value       = aws_security_group.alb.id
@@ -20,6 +19,16 @@ output "rds_security_group_id" {
 output "redis_security_group_id" {
   description = "Security group ID for ElastiCache Redis"
   value       = aws_security_group.redis.id
+}
+
+output "monitoring_security_group_id" {
+  description = "Security group ID for Monitoring tasks"
+  value       = aws_security_group.monitoring.id
+}
+
+output "efs_security_group_id" {
+  description = "Security group ID for EFS mount targets"
+  value       = aws_security_group.efs.id
 }
 
 output "ecs_task_execution_role_arn" {

--- a/infrastructure/modules/storage/main.tf
+++ b/infrastructure/modules/storage/main.tf
@@ -95,6 +95,38 @@ resource "aws_efs_access_point" "grafana" {
   }
 }
 
+resource "aws_efs_access_point" "prometheus" {
+  file_system_id = aws_efs_file_system.monitoring.id
+  posix_user {
+    gid = 65534
+    uid = 65534
+  }
+  root_directory {
+    path = "/prometheus"
+    creation_info {
+      owner_gid   = 65534
+      owner_uid   = 65534
+      permissions = "755"
+    }
+  }
+}
+
+resource "aws_efs_access_point" "alertmanager" {
+  file_system_id = aws_efs_file_system.monitoring.id
+  posix_user {
+    gid = 65534
+    uid = 65534
+  }
+  root_directory {
+    path = "/alertmanager"
+    creation_info {
+      owner_gid   = 65534
+      owner_uid   = 65534
+      permissions = "755"
+    }
+  }
+}
+
 resource "aws_efs_access_point" "loki" {
   file_system_id = aws_efs_file_system.monitoring.id
 

--- a/infrastructure/modules/storage/main.tf
+++ b/infrastructure/modules/storage/main.tf
@@ -1,9 +1,7 @@
+# =============================================================
+# S3 for ALB Access Logs
+# =============================================================
 
-# Storage Module - Main Configuration
-# S3 bucket for ALB access logs
-
-
-# ALB Access Logs Bucket
 resource "aws_s3_bucket" "alb_logs" {
   bucket = trimsuffix(substr("${var.project_name}-${var.environment}-alb-logs", 0, 63), "-")
 
@@ -55,6 +53,62 @@ resource "aws_s3_bucket_lifecycle_configuration" "alb_logs" {
     transition {
       days          = 30
       storage_class = "STANDARD_IA"
+    }
+  }
+}
+
+# =============================================================
+# EFS for Persistent Monitoring Data
+# =============================================================
+
+resource "aws_efs_file_system" "monitoring" {
+  creation_token = "${var.project_name}-${var.environment}-monitoring-efs"
+  encrypted      = true
+
+  tags = merge(var.tags, {
+    Name = "${var.project_name}-${var.environment}-monitoring-efs"
+  })
+}
+
+resource "aws_efs_mount_target" "monitoring" {
+  count           = length(var.private_subnet_ids)
+  file_system_id  = aws_efs_file_system.monitoring.id
+  subnet_id       = var.private_subnet_ids[count.index]
+  security_groups = [var.efs_security_group_id]
+}
+
+resource "aws_efs_access_point" "grafana" {
+  file_system_id = aws_efs_file_system.monitoring.id
+
+  posix_user {
+    gid = 472
+    uid = 472
+  }
+
+  root_directory {
+    path = "/grafana"
+    creation_info {
+      owner_gid   = 472
+      owner_uid   = 472
+      permissions = "755"
+    }
+  }
+}
+
+resource "aws_efs_access_point" "loki" {
+  file_system_id = aws_efs_file_system.monitoring.id
+
+  posix_user {
+    gid = 10001
+    uid = 10001
+  }
+
+  root_directory {
+    path = "/loki"
+    creation_info {
+      owner_gid   = 10001
+      owner_uid   = 10001
+      permissions = "755"
     }
   }
 }

--- a/infrastructure/modules/storage/outputs.tf
+++ b/infrastructure/modules/storage/outputs.tf
@@ -1,7 +1,6 @@
 
 # Storage Module - Outputs
 
-
 output "alb_logs_bucket_id" {
   description = "S3 bucket ID for ALB access logs"
   value       = aws_s3_bucket.alb_logs.id
@@ -10,4 +9,19 @@ output "alb_logs_bucket_id" {
 output "alb_logs_bucket_arn" {
   description = "S3 bucket ARN for ALB access logs"
   value       = aws_s3_bucket.alb_logs.arn
+}
+
+output "efs_monitoring_id" {
+  description = "ID of EFS filesystem for monitoring"
+  value       = aws_efs_file_system.monitoring.id
+}
+
+output "efs_access_point_grafana_id" {
+  description = "ID of EFS access point for Grafana"
+  value       = aws_efs_access_point.grafana.id
+}
+
+output "efs_access_point_loki_id" {
+  description = "ID of EFS access point for Loki"
+  value       = aws_efs_access_point.loki.id
 }

--- a/infrastructure/modules/storage/outputs.tf
+++ b/infrastructure/modules/storage/outputs.tf
@@ -25,3 +25,11 @@ output "efs_access_point_loki_id" {
   description = "ID of EFS access point for Loki"
   value       = aws_efs_access_point.loki.id
 }
+
+output "efs_access_point_prometheus_id" {
+  value = aws_efs_access_point.prometheus.id
+}
+
+output "efs_access_point_alertmanager_id" {
+  value = aws_efs_access_point.alertmanager.id
+}

--- a/infrastructure/modules/storage/variables.tf
+++ b/infrastructure/modules/storage/variables.tf
@@ -1,12 +1,9 @@
 
 # Storage Module - Variables
-# S3 bucket for Terraform state and logs
-
 
 variable "project_name" {
   description = "Project name used for resource naming"
   type        = string
-  default     = "quickpoll"
 }
 
 variable "environment" {
@@ -18,4 +15,14 @@ variable "tags" {
   description = "Additional tags for resources"
   type        = map(string)
   default     = {}
+}
+
+variable "private_subnet_ids" {
+  description = "IDs of private subnets for EFS mount targets"
+  type        = list(string)
+}
+
+variable "efs_security_group_id" {
+  description = "ID of security group for EFS"
+  type        = string
 }

--- a/monitoring/alertmanager/alertmanager.yml
+++ b/monitoring/alertmanager/alertmanager.yml
@@ -4,7 +4,6 @@
 
 global:
   resolve_timeout: 5m
-  slack_api_url: "https://hooks.slack.com/services/REPLACE_WITH_WEBHOOK"
 
 route:
   group_by: ["alertname", "severity", "service"]
@@ -32,6 +31,7 @@ receivers:
     slack_configs:
       - channel: "#quickpoll-alerts"
         send_resolved: true
+        api_url: "${SLACK_WEBHOOK_URL}"
         title: '{{ if eq .Status "firing" }}🔔{{ else }}✅{{ end }} [{{ .Status | toUpper }}] {{ .CommonLabels.alertname }}'
         text: >-
           *Alert:* {{ .CommonLabels.alertname }}
@@ -47,6 +47,7 @@ receivers:
     slack_configs:
       - channel: "#quickpoll-alerts"
         send_resolved: true
+        api_url: "${SLACK_WEBHOOK_URL}"
         title: '{{ if eq .Status "firing" }}🚨 CRITICAL{{ else }}✅ RESOLVED{{ end }} {{ .CommonLabels.alertname }}'
         text: >-
           🚨 *CRITICAL ALERT*

--- a/monitoring/grafana/provisioning/datasources/datasource.yml
+++ b/monitoring/grafana/provisioning/datasources/datasource.yml
@@ -10,3 +10,22 @@ datasources:
     editable: false
     jsonData:
       timeInterval: "15s"
+
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    editable: false
+    jsonData:
+      derivedFields:
+        - datasourceUid: jaeger
+          matcherRegex: "traceId=(\\w+)"
+          name: TraceID
+          url: "$${__value.raw}"
+
+  - name: Jaeger
+    type: jaeger
+    uid: jaeger
+    access: proxy
+    url: http://jaeger:16686
+    editable: false

--- a/monitoring/loki/loki-config.yml
+++ b/monitoring/loki/loki-config.yml
@@ -1,0 +1,30 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+analytics:
+  reporting_enabled: false

--- a/monitoring/promtail/promtail-config.yml
+++ b/monitoring/promtail/promtail-config.yml
@@ -1,0 +1,32 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: system
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: varlogs
+          __path__: /var/log/*log
+
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 5s
+    relabel_configs:
+      - source_labels: ["__meta_docker_container_name"]
+        regex: "/(.*)"
+        target_label: "container"
+      - source_labels: ["__meta_docker_container_log_stream"]
+        target_label: "stream"
+      - source_labels:
+          ["__meta_docker_container_label_com_docker_compose_service"]
+        target_label: "service"


### PR DESCRIPTION
## Summary
Implemented full-stack observability for QuickPoll.
- **Logging**: Grafana Loki with Promtail (local) and FireLens/Fluent Bit (AWS).
- **Tracing**: Jaeger (all-in-one locally and ECS service on AWS) using OpenTelemetry.
- **Fixes**: Excluded `/api/auth/` from JWT filter to allow registration even if an invalid token is present.
- **Infra**: Added EFS for persistent monitoring storage, configured ALB path-based routing for `/grafana/*` and `/jaeger/*`.
- **Bug**: Fixed production Terraform validation by passing missing arguments to the storage module.

## Type
- [x] Feature
- [x] Bug Fix
- [x] Infrastructure
- [ ] Tests
- [ ] Documentation

## Reviewer
@nabbi007 


## Testing
1. Run local monitoring: `docker compose --profile monitoring up -d`.
2. Check Grafana (`localhost:3000`) and Jaeger (`localhost:16686`).
3. Verify backend logs include trace IDs.
4. Verify registration works even with a fake/expired token in the header.
5. In AWS, verify Terraform validate passes for both staging and prod.

## Checklist
- [x] Tested locally
- [x] Tests pass
- [ ] Under 200 lines
- [x] Reviewer tagged

## Related Issue
Closes #

---
