### PR TITLE
fix(monitoring): pass ecs_cluster_id and fix EFS access point attributes

### DIFF
--- a/infrastructure/environments/prod/main.tf
+++ b/infrastructure/environments/prod/main.tf
@@ -159,6 +159,7 @@ module "monitoring" {
   private_subnet_ids               = module.networking.private_subnet_ids
   service_discovery_namespace_id   = module.networking.service_discovery_namespace_id
   monitoring_security_group_id     = module.security.monitoring_security_group_id
+  ecs_cluster_id                   = module.ecs.cluster_id
   ecs_task_execution_role_arn      = module.security.ecs_task_execution_role_arn
   monitoring_target_group_arn      = module.loadbalancer.monitoring_target_group_arn
   jaeger_target_group_arn          = module.loadbalancer.jaeger_target_group_arn

--- a/infrastructure/environments/staging/main.tf
+++ b/infrastructure/environments/staging/main.tf
@@ -157,6 +157,7 @@ module "monitoring" {
   private_subnet_ids               = module.networking.private_subnet_ids
   service_discovery_namespace_id   = module.networking.service_discovery_namespace_id
   monitoring_security_group_id     = module.security.monitoring_security_group_id
+  ecs_cluster_id                   = module.ecs.cluster_id
   ecs_task_execution_role_arn      = module.security.ecs_task_execution_role_arn
   monitoring_target_group_arn      = module.loadbalancer.monitoring_target_group_arn
   jaeger_target_group_arn          = module.loadbalancer.jaeger_target_group_arn

--- a/infrastructure/modules/monitoring/main.tf
+++ b/infrastructure/modules/monitoring/main.tf
@@ -54,7 +54,7 @@ resource "aws_ecs_task_definition" "jaeger" {
 
 resource "aws_ecs_service" "jaeger" {
   name            = "${var.project_name}-${var.environment}-jaeger"
-  cluster         = "${var.project_name}-${var.environment}-cluster"
+  cluster         = var.ecs_cluster_id
   task_definition = aws_ecs_task_definition.jaeger.arn
   desired_count   = 1
   launch_type     = "FARGATE"
@@ -141,7 +141,7 @@ resource "aws_ecs_task_definition" "loki" {
 
 resource "aws_ecs_service" "loki" {
   name            = "${var.project_name}-${var.environment}-loki"
-  cluster         = "${var.project_name}-${var.environment}-cluster"
+  cluster         = var.ecs_cluster_id
   task_definition = aws_ecs_task_definition.loki.arn
   desired_count   = 1
   launch_type     = "FARGATE"
@@ -212,7 +212,7 @@ resource "aws_ecs_task_definition" "grafana" {
 
 resource "aws_ecs_service" "grafana" {
   name            = "${var.project_name}-${var.environment}-grafana"
-  cluster         = "${var.project_name}-${var.environment}-cluster"
+  cluster         = var.ecs_cluster_id
   task_definition = aws_ecs_task_definition.grafana.arn
   desired_count   = 1
   launch_type     = "FARGATE"
@@ -321,7 +321,7 @@ resource "aws_ecs_task_definition" "prometheus" {
 
 resource "aws_ecs_service" "prometheus" {
   name            = "${var.project_name}-${var.environment}-prometheus"
-  cluster         = "${var.project_name}-${var.environment}-cluster"
+  cluster         = var.ecs_cluster_id
   task_definition = aws_ecs_task_definition.prometheus.arn
   desired_count   = 1
   launch_type     = "FARGATE"
@@ -403,7 +403,7 @@ resource "aws_ecs_task_definition" "alertmanager" {
 
 resource "aws_ecs_service" "alertmanager" {
   name            = "${var.project_name}-${var.environment}-alertmanager"
-  cluster         = "${var.project_name}-${var.environment}-cluster"
+  cluster         = var.ecs_cluster_id
   task_definition = aws_ecs_task_definition.alertmanager.arn
   desired_count   = 1
   launch_type     = "FARGATE"

--- a/infrastructure/modules/monitoring/variables.tf
+++ b/infrastructure/modules/monitoring/variables.tf
@@ -23,6 +23,11 @@ variable "monitoring_security_group_id" {
   type = string
 }
 
+variable "ecs_cluster_id" {
+  description = "The ID or ARN of the ECS cluster"
+  type        = string
+}
+
 variable "ecs_task_execution_role_arn" {
   type = string
 }


### PR DESCRIPTION
## Summary
Fix monitoring module ECS service configuration by passing the `ecs_cluster_id` from the environment modules (staging and production) to the monitoring module.  
This ensures all monitoring services correctly reference the existing ECS cluster instead of using a hardcoded cluster name.

## Type
- [ ] Feature
- [x] Bug Fix
- [x] Infrastructure
- [ ] Tests
- [ ] Documentation

## Reviewer

@nabbi007 

> PRs to `main` **require** @Lennox-Owusu approval.

---

## Changes Made
- Added `ecs_cluster_id` variable to the monitoring module.
- Passed `ecs_cluster_id` from environment modules (`staging` and `prod`).
- Updated ECS services in the monitoring module to use `var.ecs_cluster_id` instead of a hardcoded cluster name.

Affected services:
- Jaeger
- Loki
- Grafana
- Prometheus
- Alertmanager

---

## Testing
Steps to test these changes:

1. Navigate to the infrastructure environment directory:
   ```bash
   cd infrastructure/environments/staging