### PR TITLE
Fix: Fixed csrf to enable codeql checks

### DIFF
--- a/backend/src/main/java/com/amalitech/quickpoll/config/SecurityConfig.java
+++ b/backend/src/main/java/com/amalitech/quickpoll/config/SecurityConfig.java
@@ -36,10 +36,11 @@ public class SecurityConfig {
     private final CustomUserDetailService customUserDetailService;
     private final JwtAuthenticationEntryPoint entryPoint;
 
+    @SuppressWarnings("java/spring-disabled-csrf-protection")
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-            .csrf(AbstractHttpConfigurer::disable)
+            .csrf(AbstractHttpConfigurer::disable) // Intentional: stateless JWT, no session cookies
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .exceptionHandling(ex -> ex
                         .authenticationEntryPoint(entryPoint)
@@ -63,6 +64,7 @@ public class SecurityConfig {
 
         return http.build();
     }
+
 
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {


### PR DESCRIPTION
## Summary
Dismisses a false positive CodeQL alert for disabled CSRF protection. This API uses stateless JWT authentication with no session cookies, making CSRF protection unnecessary and inapplicable.

## Type
- [ ] Feature
- [ ] Bug Fix
- [ ] Infrastructure
- [ ] Tests
- [x] Documentation

Tag your assigned review partner based on your role area
| Role | Reviewers |
|------|-----------|
| **Backend** | @mahorobonheur @GargoilXD |

## Testing
1. Verify the CodeQL alert "Disabled Spring CSRF protection #1" is resolved after next scan
2. Confirm all existing auth endpoints still return expected status codes (login, register, protected routes)

## Checklist
- [x] Tested locally
- [x] Tests pass
- [x] Under 200 lines
- [x] Reviewer tagged

## Related Issue
Closes #1

---
**Note:** CSRF is intentionally disabled — app is stateless JWT with no session cookies. This is not a security vulnerability.
